### PR TITLE
docs: update CHANGELOG with March 2026 dependency bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shopify/shopify-app-template-remix
 
+## 2026.03.02
+
+- Bump `actions/setup-node` from 5.0.0 to 6.2.0 to support Node.js 22 LTS and improved caching performance
+- Bump `actions/checkout` from 2.7.0 to 6.0.2 with improved ref handling, worktree support, and Node.js 24 compatibility
+- Bump `actions-cool/issues-helper` from 3.6.3 to 3.7.6 for latest issue management improvements
+
 ## 2025.12.11
 
 - [#1201](https://github.com/Shopify/shopify-app-template-remix/pull/1201) Update `@shopify/shopify-app-remix` to v4.1.0 and `@shopify/shopify-app-session-storage-prisma` to v8.0.0, add refresh token fields (`refreshToken` and `refreshTokenExpires`) to Session model in Prisma schema, and adopt the `expiringOfflineAccessTokens` flag for enhanced security through token rotation. See [expiring vs non-expiring offline tokens](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/offline-access-tokens#expiring-vs-non-expiring-offline-tokens) for more information.


### PR DESCRIPTION
Documents the GitHub Actions dependency updates merged via Dependabot (actions/setup-node, actions/checkout, actions-cool/issues-helper).